### PR TITLE
fix: FlipClockDigit does not transition

### DIFF
--- a/src/FlipClockDigit.tsx
+++ b/src/FlipClockDigit.tsx
@@ -13,7 +13,7 @@ type FlipClockDigitState = FlipClockDigitProps;
 
 export default function FlipClockDigit(props: FlipClockDigitProps) {
   const { current, next, className } = props;
-  const [digit, setDigit] = React.useState<FlipClockDigitState>({ current: 0, next: 0 });
+  const [digit, setDigit] = React.useState<FlipClockDigitState>({ current, next });
   const [flipped, setFlipped] = React.useState(false);
 
   React.useEffect(() => {


### PR DESCRIPTION
When the component is rerendered many times and too fast, the onTransitionEnd event will be reset. Setting the default state of FlipClockDigit to `{current: 0, digit: 0}` will cause the state update to fail and display wrong UI.
Reset FlipClockDigit initial state to the same value in props will fix this bug