### PR TITLE
feat: add controls if user want to control the component

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The <code>FlipClockCountdown</code> has all properties of `div` and additional p
 | **dividerStyle**                          |            <code>object</code>            |    no    |                <code>undefined</code>                | The style will be applied to divider, includes `color` and `height`.                                                                                                             |
 | **duration**                              |            <code>number</code>            |    no    |                   <code>0.7</code>                   | Duration (in second) when flip card. Valid value in range (0, 1).                                                                                                                |
 | **hideOnComplete**                        |           <code>boolean</code>            |    no    |                  <code>true</code>                   | By befault, the countdown will be hidden when it completed (or show children if provided). This will keep the timer in place and stuck at zeros when the countdown is completed. |
+| **controls**                              |           <code>boolean</code>            |    no    |                  <code>false</code>                  | Set it to true if you went to control the countdown.                                                                                                                             |
 
 ### `to`
 
@@ -95,6 +96,35 @@ class Example extends Component {
     return <FlipClockCountdown to={new Date().getTime() + 24 * 3600 * 1000 + 5000} />;
   }
 }
+```
+
+### Controlled usage
+
+```tsx
+import React, { useRef } from 'react';
+
+import FlipClockCountdown from '@leenguyen/react-flip-clock-countdown';
+import '@leenguyen/react-flip-clock-countdown/dist/index.css';
+
+const App = () => {
+  const flipRef = useRef<any>(null);
+
+  const run = () => {
+    flipRef.current?.run();
+  };
+
+  const stop = () => {
+    flipRef.current?.stop();
+  };
+
+  return (
+    <div>
+      <FlipClockCountdown controls ref={flipRef} to={new Date().getTime() + 24 * 3600 * 1000 + 5000} />
+      <button onClick={run}>Run</button>
+      <button onClick={stop}>Stop</button>
+    </div>
+  );
+};
 ```
 
 ### Render a React Component when countdown is complete

--- a/examples/react-app/src/App.tsx
+++ b/examples/react-app/src/App.tsx
@@ -1,14 +1,31 @@
-import React from 'react';
-
+import React, { useRef } from 'react';
 import FlipClockCountdown from 'react-flip-clock-countdown';
 
 const App = () => {
+  const flipRef = useRef<any>(null);
+
+  const run = () => {
+    flipRef.current?.run();
+  };
+
+  const stop = () => {
+    flipRef.current?.stop();
+  };
+
   return (
     <React.Fragment>
       <h1>React flip-clock countdown</h1>
       <div style={{ marginBottom: 30 }}>
         <h2>Default</h2>
         <FlipClockCountdown to={new Date().getTime() + 24 * 3600 * 1000 + 5000}>Finished</FlipClockCountdown>
+      </div>
+      <div style={{ marginBottom: 30 }}>
+        <h2>Control</h2>
+        <FlipClockCountdown controls ref={flipRef} to={new Date().getTime() + 24 * 3600 * 1000 + 5000}>
+          Finished
+        </FlipClockCountdown>
+        <button onClick={run}>Run</button>
+        <button onClick={stop}>Stop</button>
       </div>
       <div style={{ marginBottom: 30 }}>
         <h1>Default without completion component</h1>

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,11 @@ export interface FlipClockCountdownState {
   readonly completed: boolean;
 }
 
+export interface FlipClockRefType {
+  readonly run: () => void;
+  readonly stop: () => void;
+}
+
 export type FlipClockCountdownTimeDeltaFn = (props: FlipClockCountdownState) => void;
 
 export interface FlipClockCountdownProps
@@ -69,6 +74,12 @@ export interface FlipClockCountdownProps
    * @default ['Days', 'Hours', 'Minutes', 'Seconds']
    */
   readonly labels?: [string, string, string, string];
+  /**
+   * Set it to `true` if you want to control the countdown.
+   *
+   * @default false
+   */
+  readonly controls?: boolean;
   /**
    * Set it to `false` if you don't want to show the labels.
    *


### PR DESCRIPTION
Hello, I need to control the countdown when using [react-flip-clock-countdown](https://github.com/sLeeNguyen/react-flip-clock-countdown), so I added some code in this repository. 

If you find some problems, please reply to me. 😅

Set **controls** to true if you want to control the countdown by yourself.

I exposed two methods ( **stop** & **run** ) when controls is true. 



### Example:

```tsx
import React, { useRef } from 'react';

import FlipClockCountdown from '@leenguyen/react-flip-clock-countdown';
import '@leenguyen/react-flip-clock-countdown/dist/index.css';

const App = () => {
  const flipRef = useRef<any>(null);

  const run = () => {
    flipRef.current?.run();
  };

  const stop = () => {
    flipRef.current?.stop();
  };

  return (
    <div>
      <FlipClockCountdown controls ref={flipRef} to={new Date().getTime() + 24 * 3600 * 1000 + 5000} />
      <button onClick={run}>Run</button>
      <button onClick={stop}>Stop</button>
    </div>
  );
};
```

Hope to pass pr! Thanks.