### PR TITLE
Add labels to sections dependency list

### DIFF
--- a/src/FlipClockCountDown.tsx
+++ b/src/FlipClockCountDown.tsx
@@ -163,7 +163,7 @@ function FlipClockCountdown(props: FlipClockCountdownProps) {
         return [show, keys[i], times[i], _labels[i]];
       })
       .filter((item) => item[0]);
-  }, [renderMap, state]);
+  }, [labels, renderMap, state]);
 
   if (state?.completed && hideOnComplete) {
     return <React.Fragment>{children}</React.Fragment>;


### PR DESCRIPTION
There is a super minor edge case in which the labels do not update due to the sections being memoized and the dependency array only contains renderMap and state.

Example situation:
1) Default renderMap is used, which makes the renderMap variable unchanged between renders.
2) Timer is completed and hideOnComplete={false}, which makes the state variable unchanged between renders.
3) Labels are changed (example: clicking a button on the page to toggle the language and change the countdown labels).

In this situation, the labels remain unchanged, since the sections variable does not get re-calculated, as the renderMap and state in the dependency array remain unchanged.

Fix in this PR:
This is a pretty simple and easy fix, which is just to include the labels array in the dependency array of the sections variable. That way sections will get re-calculated every time the labels input changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * FlipClockCountdown now updates its section labels immediately when the labels prop changes, preventing stale or incorrect text.
  * Improves reliability for dynamic localization/translation updates without requiring a remount or manual refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->