### PR TITLE
feat: support ReactElement in labels prop for enhanced customization

### DIFF
--- a/examples/next-app/pages/index.js
+++ b/examples/next-app/pages/index.js
@@ -87,6 +87,124 @@ const Example = () => {
           renderMap={[true, true, true, false]}
         />
       </div>
+
+      <div style={{ marginBottom: 30 }}>
+        <h2>ReactElement Labels - Basic</h2>
+        <FlipClockCountdown
+          to={new Date().getTime() + 24 * 3600 * 1000 + 5000}
+          labels={[
+            <span style={{ color: '#ff6b6b', fontWeight: 'bold' }}>Days</span>,
+            <span style={{ color: '#4ecdc4', fontWeight: 'bold' }}>Hours</span>,
+            <span style={{ color: '#45b7d1', fontWeight: 'bold' }}>Minutes</span>,
+            <span style={{ color: '#96ceb4', fontWeight: 'bold' }}>Seconds</span>
+          ]}
+        />
+      </div>
+
+      <div style={{ marginBottom: 30 }}>
+        <h2>ReactElement Labels - With Icons</h2>
+        <FlipClockCountdown
+          to={new Date().getTime() + 24 * 3600 * 1000 + 5000}
+          labels={[
+            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <span role='img' aria-label='calendar'>
+                📅
+              </span>
+              <span>Days</span>
+            </div>,
+            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <span role='img' aria-label='clock'>
+                ⏰
+              </span>
+              <span>Hours</span>
+            </div>,
+            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <span role='img' aria-label='hourglass'>
+                ⏳
+              </span>
+              <span>Minutes</span>
+            </div>,
+            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <span role='img' aria-label='stopwatch'>
+                ⏱️
+              </span>
+              <span>Seconds</span>
+            </div>
+          ]}
+          labelStyle={{ fontSize: 12 }}
+        />
+      </div>
+
+      <div style={{ marginBottom: 30 }}>
+        <h2>ReactElement Labels - Custom Components</h2>
+        <FlipClockCountdown
+          to={new Date().getTime() + 24 * 3600 * 1000 + 5000}
+          labels={[
+            <div
+              style={{
+                padding: '4px 8px',
+                background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                borderRadius: '4px',
+                color: 'white',
+                fontSize: '10px',
+                fontWeight: 'bold'
+              }}
+            >
+              DAYS
+            </div>,
+            <div
+              style={{
+                padding: '4px 8px',
+                background: 'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+                borderRadius: '4px',
+                color: 'white',
+                fontSize: '10px',
+                fontWeight: 'bold'
+              }}
+            >
+              HOURS
+            </div>,
+            <div
+              style={{
+                padding: '4px 8px',
+                background: 'linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)',
+                borderRadius: '4px',
+                color: 'white',
+                fontSize: '10px',
+                fontWeight: 'bold'
+              }}
+            >
+              MINS
+            </div>,
+            <div
+              style={{
+                padding: '4px 8px',
+                background: 'linear-gradient(135deg, #43e97b 0%, #38f9d7 100%)',
+                borderRadius: '4px',
+                color: 'white',
+                fontSize: '10px',
+                fontWeight: 'bold'
+              }}
+            >
+              SECS
+            </div>
+          ]}
+          digitBlockStyle={{ width: 50, height: 70, fontSize: 40 }}
+        />
+      </div>
+
+      <div style={{ marginBottom: 30 }}>
+        <h2>Mixed - String and ReactElement</h2>
+        <FlipClockCountdown
+          to={new Date().getTime() + 24 * 3600 * 1000 + 5000}
+          labels={[
+            'Days',
+            <strong style={{ color: '#e74c3c' }}>Hours</strong>,
+            'Minutes',
+            <em style={{ color: '#3498db' }}>Seconds</em>
+          ]}
+        />
+      </div>
     </React.Fragment>
   );
 };

--- a/examples/react-app/src/App.tsx
+++ b/examples/react-app/src/App.tsx
@@ -42,6 +42,26 @@ const App = () => {
             labels={['DAYS', 'HOURS', 'MINUTES', 'SECONDS']}
           />
         </div>
+
+        <h2>Element labels</h2>
+        <div style={{ marginBottom: 70 }}>
+          <FlipClockCountdown
+            className='flip-clock'
+            to={new Date().getTime() + 24 * 3600 * 1000 + 5000}
+            labels={[
+              <div>
+                Element
+                <br />
+                Label
+                <br />
+                with BR Tag
+              </div>,
+              'HOURS',
+              'MINUTES',
+              'SECONDS'
+            ]}
+          />
+        </div>
         <div>
           <FlipClockCountdown
             className='flip-clock'

--- a/src/FlipClockCountDown.spec.tsx
+++ b/src/FlipClockCountDown.spec.tsx
@@ -231,3 +231,63 @@ test('should render the countdown with daysInHours enabled', () => {
   expect(() => screen.getByText('Seconds')).toThrow();
   expect(container2.children.length).toEqual(1); // 1 rendered section
 });
+
+test('should render the countdown with ReactElement labels', () => {
+  render(
+    <FlipClockCountdown
+      to={new Date().getTime() + 24 * 3600 * 1000 + 5000}
+      labels={[
+        <span data-testid='custom-days'>DAYS</span>,
+        <span data-testid='custom-hours'>HOURS</span>,
+        <span data-testid='custom-minutes'>MINUTES</span>,
+        <span data-testid='custom-seconds'>SECONDS</span>
+      ]}
+    />
+  );
+  expect(screen.getByTestId('custom-days')).toBeInTheDocument();
+  expect(screen.getByTestId('custom-hours')).toBeInTheDocument();
+  expect(screen.getByTestId('custom-minutes')).toBeInTheDocument();
+  expect(screen.getByTestId('custom-seconds')).toBeInTheDocument();
+  expect(screen.getByText('DAYS')).toBeInTheDocument();
+  expect(screen.getByText('HOURS')).toBeInTheDocument();
+  expect(screen.getByText('MINUTES')).toBeInTheDocument();
+  expect(screen.getByText('SECONDS')).toBeInTheDocument();
+});
+
+test('should render the countdown with mixed string and ReactElement labels', () => {
+  render(
+    <FlipClockCountdown
+      to={new Date().getTime() + 24 * 3600 * 1000 + 5000}
+      labels={[<strong data-testid='bold-days'>D</strong>, 'H', <em data-testid='italic-minutes'>M</em>, 'S']}
+    />
+  );
+  expect(screen.getByTestId('bold-days')).toBeInTheDocument();
+  expect(screen.getByText('D')).toBeInTheDocument();
+  expect(screen.getByText('H')).toBeInTheDocument();
+  expect(screen.getByTestId('italic-minutes')).toBeInTheDocument();
+  expect(screen.getByText('M')).toBeInTheDocument();
+  expect(screen.getByText('S')).toBeInTheDocument();
+});
+
+test('should render the countdown with complex ReactElement labels containing icons and text', () => {
+  const DayLabel = () => (
+    <div data-testid='complex-label'>
+      <span role='img' aria-label='calendar'>
+        📅
+      </span>{' '}
+      Days
+    </div>
+  );
+
+  render(
+    <FlipClockCountdown
+      to={new Date().getTime() + 24 * 3600 * 1000 + 5000}
+      labels={[<DayLabel />, 'Hours', 'Minutes', 'Seconds']}
+    />
+  );
+
+  expect(screen.getByTestId('complex-label')).toBeInTheDocument();
+  expect(screen.getByRole('img', { name: 'calendar' })).toBeInTheDocument();
+  expect(screen.getByText('Days')).toBeInTheDocument();
+  expect(screen.getByText('Hours')).toBeInTheDocument();
+});

--- a/src/FlipClockCountDown.tsx
+++ b/src/FlipClockCountDown.tsx
@@ -3,7 +3,12 @@ import styles from './styles.module.css';
 import clsx from 'clsx';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import FlipClockDigit from './FlipClockDigit';
-import { FlipClockCountdownProps, FlipClockCountdownState, FlipClockCountdownUnitTimeFormatted } from './types';
+import {
+  FlipClockCountdownProps,
+  FlipClockCountdownState,
+  FlipClockCountdownUnitTimeFormatted,
+  FlipClockCountdownLabel
+} from './types';
 import { calcTimeDelta, convertToPx, parseTimeDelta } from './utils';
 
 const defaultRenderMap = [true, true, true, true];
@@ -159,7 +164,7 @@ function FlipClockCountdown(props: FlipClockCountdownProps) {
     const times = Object.values(formatted) as FlipClockCountdownUnitTimeFormatted[];
     const keys = ['day', 'hour', 'minute', 'second'];
     return _renderMap
-      .map<[boolean, string, FlipClockCountdownUnitTimeFormatted, string]>((show, i) => {
+      .map<[boolean, string, FlipClockCountdownUnitTimeFormatted, FlipClockCountdownLabel]>((show, i) => {
         return [show, keys[i], times[i], _labels[i]];
       })
       .filter((item) => item[0]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,8 @@ export interface FlipClockCountdownState {
 
 export type FlipClockCountdownTimeDeltaFn = (props: FlipClockCountdownState) => void;
 
+export type FlipClockCountdownLabel = string | React.ReactElement;
+
 export interface FlipClockCountdownProps
   extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
   /**
@@ -83,7 +85,12 @@ export interface FlipClockCountdownProps
    *
    * @default ['Days', 'Hours', 'Minutes', 'Seconds']
    */
-  readonly labels?: [string, string, string, string];
+  readonly labels?: [
+    FlipClockCountdownLabel,
+    FlipClockCountdownLabel,
+    FlipClockCountdownLabel,
+    FlipClockCountdownLabel
+  ];
   /**
    * Set it to `false` if you don't want to show the labels.
    *


### PR DESCRIPTION
## Summary

Extends the `labels` prop to accept `React.ReactElement`, enabling custom components, icons, and styled elements as countdown labels.

## Changes

- Added `FlipClockLabel` type: `string | React.ReactElement`
- Updated `labels` prop to support ReactElement
- Added 3 comprehensive test cases
- Added usage examples to both react-app and next-app

## Example Usage

```tsx
// Basic styled labels
<FlipClockCountdown
  labels={[
    <span style={{ color: '#ff6b6b' }}>Days</span>,
    // ...
  ]}
/>

// With icons
<FlipClockCountdown
  labels={[
    <div>📅 Days</div>,
    // ...
  ]}
/>

// Mixed string and ReactElement
<FlipClockCountdown
  labels={['Days', <strong>Hours</strong>, 'Minutes', 'Seconds']}
/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Labels prop now accepts React elements/components in addition to text, enabling custom-styled or icon-enhanced labels.
  * New example blocks showcase multiple label-rendering strategies (styled elements, icons, mixed content) for the countdown.

* **Tests**
  * Added tests covering React-element labels and mixed string/element label scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->